### PR TITLE
Fix file name issue when attempting to compile PDF on Linux

### DIFF
--- a/probability_cheatsheet.tex
+++ b/probability_cheatsheet.tex
@@ -883,7 +883,7 @@ Let us say that $X$ is distributed $\Gam(a, \lambda)$. We know the following:
 \subsection{Beta Distribution}
 \begin{minipage}{\linewidth}
             \centering
-\includegraphics[width=1.9in]{figures/betapdfs.pdf}
+\includegraphics[width=1.9in]{figures/Betapdfs.pdf}
         \end{minipage}
 \medskip
 


### PR DESCRIPTION
Didn't compile on Linux due to case-sensitivity issue in file name.