### PR TITLE
Specified lambda value of Binomial to Poisson approximation

### DIFF
--- a/probability_cheatsheet.tex
+++ b/probability_cheatsheet.tex
@@ -975,7 +975,7 @@ Let us say that $X$ is distributed \Bin($n,p$). We know the following:
 \item \textbf{Redefine success} $n-X \sim \Bin(n,1-p)$
 \item \textbf{Sum} $X+Y \sim \Bin(n+m,p)$
 \item \textbf{Conditional} $X|(X+Y=r) \sim \HGeom(n,m,r)$
- \item \textbf{Binomial-Poisson Relationship} $\Bin(n, p)$ is approximately  $\Pois(\lambda)$ if $p$ is small.
+ \item \textbf{Binomial-Poisson Relationship} $\Bin(n, p)$ is approximately  $\Pois(np)$ if $p$ is small.
    \item \textbf{Binomial-Normal Relationship} $\Bin(n, p)$ is approximately $\N(np,np(1-p))$ if $n$ is large and $p$ is not near $0$ or $1$.
   \end{itemize}
 \end{description}


### PR DESCRIPTION
Replaced de `\lambda` parameter of the Poisson approximation by the `np` value from the Binomial distribution